### PR TITLE
Improve CLI error handling

### DIFF
--- a/instancer.cli/Commands/HelpCommand.cs
+++ b/instancer.cli/Commands/HelpCommand.cs
@@ -1,0 +1,44 @@
+using CommandLine;
+
+namespace instancer.cli.Commands;
+
+[Verb("help", HelpText = "Show help for commands.")]
+public class HelpOptions
+{
+    [Value(0, MetaName = "command", HelpText = "Command to show help for.")]
+    public string? Command { get; set; }
+}
+
+public static class HelpCommand
+{
+    public static void Run(HelpOptions opts)
+    {
+        if (string.IsNullOrEmpty(opts.Command))
+        {
+            Parser.Default.ParseArguments<UpOptions, DownOptions, HelpOptions>(new[] { "--help" });
+            return;
+        }
+
+        var cmd = opts.Command!.ToLowerInvariant();
+        switch (cmd)
+        {
+            case "up":
+                Parser.Default.ParseArguments<UpOptions>(new[] { "--help" });
+                break;
+            case "down":
+                Parser.Default.ParseArguments<DownOptions>(new[] { "--help" });
+                break;
+            case "help":
+                Parser.Default.ParseArguments<HelpOptions>(new[] { "--help" });
+                break;
+            default:
+                Console.Error.WriteLine($"Unknown command '{opts.Command}'.");
+                var suggestion = Utils.Suggest(cmd, new[] { "up", "down", "help" });
+                if (suggestion != null)
+                {
+                    Console.Error.WriteLine($"Did you mean this?\n\t{suggestion}");
+                }
+                break;
+        }
+    }
+}

--- a/instancer.cli/Program.cs
+++ b/instancer.cli/Program.cs
@@ -5,13 +5,33 @@ namespace instancer.cli;
 
 public static class Program
 {
+    private static readonly string[] _commands = ["up", "down", "help"];
+
     public static int Main(string[] args)
     {
+        if (args.Length > 0 && args[0] == "help")
+        {
+            HelpCommand.Run(new HelpOptions { Command = args.Length > 1 ? args[1] : null });
+            return 0;
+        }
+
+        if (args.Length > 0 && !args[0].StartsWith("-") && Array.IndexOf(_commands, args[0]) == -1)
+        {
+            Console.Error.WriteLine($"Unknown command '{args[0]}'.");
+            var suggestion = Utils.Suggest(args[0], _commands);
+            if (suggestion != null)
+            {
+                Console.Error.WriteLine($"Did you mean this?\n\t{suggestion}");
+            }
+            return 1;
+        }
+
         return Parser.Default
-            .ParseArguments<UpOptions, DownOptions>(args)
+            .ParseArguments<UpOptions, DownOptions, HelpOptions>(args)
             .MapResult(
                 (UpOptions opts) => { UpCommand.Run(opts); return 0; },
                 (DownOptions opts) => { DownCommand.Run(opts); return 0; },
+                (HelpOptions opts) => { HelpCommand.Run(opts); return 0; },
                 errs => 1);
     }
 }

--- a/instancer.cli/Utils.cs
+++ b/instancer.cli/Utils.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace instancer.cli;
+
+public static class Utils
+{
+    public static int LevenshteinDistance(string a, string b)
+    {
+        if (string.IsNullOrEmpty(a)) return b.Length;
+        if (string.IsNullOrEmpty(b)) return a.Length;
+        var d = new int[a.Length + 1, b.Length + 1];
+        for (int i = 0; i <= a.Length; i++) d[i, 0] = i;
+        for (int j = 0; j <= b.Length; j++) d[0, j] = j;
+        for (int i = 1; i <= a.Length; i++)
+        {
+            for (int j = 1; j <= b.Length; j++)
+            {
+                int cost = a[i - 1] == b[j - 1] ? 0 : 1;
+                d[i, j] = Math.Min(
+                    Math.Min(d[i - 1, j] + 1, d[i, j - 1] + 1),
+                    d[i - 1, j - 1] + cost);
+            }
+        }
+        return d[a.Length, b.Length];
+    }
+
+    public static string? Suggest(string input, IEnumerable<string> options)
+    {
+        int min = int.MaxValue;
+        string? closest = null;
+        foreach (var option in options)
+        {
+            int dist = LevenshteinDistance(input, option);
+            if (dist < min)
+            {
+                min = dist;
+                closest = option;
+            }
+        }
+        if (closest == null || min > input.Length) return null;
+        return closest;
+    }
+}


### PR DESCRIPTION
## Summary
- add Levenshtein-based suggestion helper
- create `help` verb with optional command argument
- detect unknown commands and give suggestions

## Testing
- `dotnet build instancer.sln`
- `dotnet run --project instancer.cli -- help up`
- `dotnet run --project instancer.cli -- help foo`
- `dotnet run --project instancer.cli -- fooo`

------
https://chatgpt.com/codex/tasks/task_e_6861c8c3e0e88323bc7704e0f1363b73